### PR TITLE
Update document details: title, editors, spec status, references

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ var respecConfig = {
       url: "https://www.standblog.org/",
       company: "Invited Expert",
       w3cid: 495082
-    }
+    },
     {
       name: "Lola Odelola",
       url: "https://lolaslab.co/",

--- a/index.html
+++ b/index.html
@@ -1,29 +1,37 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Self-review questionnaire: Societal Impact</title>
+<title>Self-Review Questionnaire: Societal Impact</title>
 <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c">
 </script>
 <script class="remove">
 var respecConfig = {
-  specStatus: "draft-finding",
+  specStatus: "editor-draft-finding",
   editors: [
     {
-      name: "Amy Guy",
-      url: "https://rhiaro.co.uk",
-      company: "Digital Bazaar",
+      name: "Sarven Capadisli",
+      url: "https://csarven.ca/",
+      company: "Invited Expert",
+      w3cid: 46140
     },
+    {
+      name: "Tristan Nitot",
+      url: "https://www.standblog.org/",
+      company: "OCTO Technology",
+      companyURL: "https://octo.com/",
+      w3cid: 495082
+    }
   ],
+  formerEditors: [{
+    name: "Amy Guy",
+    url: "https://rhiaro.co.uk/",
+    company: "Digital Bazaar",
+    companyURL: "https://digitalbazaar.com/",
+    w3cid: 69000
+  }],
   group: "tag",
   wgPublicList: "www-tag",
   github: "w3ctag/societal-impact-questionnaire",
-  format: "markdown",
-  localBiblio: {
-    "EWP" : {
-      title: "Ethical Web Principles",
-      href: "https://www.w3.org/2001/tag/doc/ethical-web-principles/",
-      publisher: "W3C",
-    },
-  },
+  format: "markdown"
 };
 </script>
 <body class="informative">
@@ -69,7 +77,7 @@ benefit to a small number may result in a wider society where the same threat
 or benefit is commonplace, when the technology is available as part of the web
 platform.
 
-These questions are an accompaniment to the [[EWP|Ethical Web Principles]],
+These questions are an accompaniment to the [[ethical-web-principles|Ethical Web Principles]],
 intended to help specification authors and reviewers to think more concretely
 about the ethical implications of particular specification features.
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 </script>
 <script class="remove">
 var respecConfig = {
-  specStatus: "editor-draft-finding",
+  specStatus: "draft-finding",
   editors: [
     {
       name: "Sarven Capadisli",

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@ benefit to a small number may result in a wider society where the same threat
 or benefit is commonplace, when the technology is available as part of the web
 platform.
 
-These questions are an accompaniment to the [[ethical-web-principles|Ethical Web Principles]],
+These questions are an accompaniment to the [[[ethical-web-principles]]],
 intended to help specification authors and reviewers to think more concretely
 about the ethical implications of particular specification features.
 

--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@ var respecConfig = {
       company: "Invited Expert",
       w3cid: 495082
     }
+    {
+      name: "Lola Odelola",
+      url: "https://lolaslab.co/",
+      company: "Invited Expert",
+      w3cid: 127012
+    }
   ],
   formerEditors: [{
     name: "Amy Guy",

--- a/index.html
+++ b/index.html
@@ -16,8 +16,7 @@ var respecConfig = {
     {
       name: "Tristan Nitot",
       url: "https://www.standblog.org/",
-      company: "OCTO Technology",
-      companyURL: "https://octo.com/",
+      company: "Invited Expert",
       w3cid: 495082
     }
   ],


### PR DESCRIPTION
Updating minor document details, including title casing, editor listings (adding myself and @nitot as current editors and @rhiaro as a former editor), adopting `editor-draft-finding` spec status (to avoid using the outdated datedspace, as per ReSpec's suggestion), and updating the link to the EWP Statement.