### PR TITLE
Refine measuring impact example: bicycle safety impact and data categorisation

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,9 @@ Example: If a local government decides to add separated bicycle lanes and
 improved signalling, they should expect increased bicycle use and a reduction in
 collisions involving bicycles. They can measure this by collecting automated,
 non-identified traffic data and by analysing transportation safety statistics,
-while being mindful of how such incidents are categorised in official records, e.g., misclassified as bicycle accidents instead of automobile accidents or grouped under general traffic accidents.
+while being mindful of how such incidents are categorised in official records,
+e.g., misclassified as bicycle accidents instead of automobile accidents or
+grouped under general traffic accidents.
 
 </aside>
 

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@ Example: If a local government decides to add separated bicycle lanes and
 improved signalling, they should expect increased bicycle use and a reduction in
 collisions involving bicycles. They can measure this by collecting automated,
 non-identified traffic data and by analysing transportation safety statistics,
-while being mindful of how such incidents are categorised in official records.
+while being mindful of how such incidents are categorised in official records, e.g., misclassified as bicycle accidents instead of automobile accidents or grouped under general traffic accidents.
 
 </aside>
 

--- a/index.html
+++ b/index.html
@@ -87,10 +87,11 @@ impact, you are not putting people at risk.
 
 <aside class="example" title="Measuring impact" id="example-measuring">
 
-Example: if a local government decides to add separated bicycle lanes and
-signalling then they should expect fewer bicycle accidents and more use of
-bicycles.  They can measure that by collecting automated non-identified traffic
-data and by monitoring published statistics about bicycle accidents.
+Example: If a local government decides to add separated bicycle lanes and
+improved signalling, they should expect increased bicycle use and a reduction in
+collisions involving bicycles. They can measure this by collecting automated,
+non-identified traffic data and by analysing transportation safety statistics,
+while being mindful of how such incidents are categorised in official records.
 
 </aside>
 


### PR DESCRIPTION
Tweaks the wording around bicycle-related accidents and how data is categorised. The aim is to avoid suggesting that bicycles are the main cause of accidents while also recognising possible biases in how accident data is recorded.

See also:
* "Scofflaw cyclist"
* https://road-safety.transport.ec.europa.eu/system/files/2022-06/road_safety_thematic_report_cyclists.pdf
* https://bikeleague.org/better-crash-data-that-doesnt-victim-blame/
* ...