### PR TITLE
Add purpose section to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,11 +87,11 @@ This document is not a checklist for specifications. It is not included as
 part of the horizontal review process and is not intended for specification
 authors to use as acceptance criteria.
 
-The questions in this document are to help specification authors as they think
-through the impacts implementations of their features may have, both in the
-immediate scope of their work, as well as more widely. The questions encourage
-the reader to think about perspectives other than their own, as well as to
-think about worst case scenarios.
+The questions in this document are meant to help specification authors think
+through the impacts that implementations of their features may have, both in the
+immediate scope of their work and more widely. The questions encourage the reader
+to consider perspectives other than their own, as well as to consider worst-case
+scenarios.
 
 These questions are an accompaniment to the [[[ethical-web-principles]]],
 intended to help specification authors and reviewers to think more concretely

--- a/index.html
+++ b/index.html
@@ -83,9 +83,9 @@ platform.
 
 ### The purpose of this document {#purpose}
 
-This document is not a checklist for specifications. This document is not included as 
-part of the horizontal review process and is notintended for spec authors to 
-use as acceptance criteria.
+This document is not a checklist for specifications. It is not included as 
+part of the horizontal review process and is not intended for specification
+authors to use as acceptance criteria.
 
 The questions in this document are to help specification authors as they think
 through the impacts implementations of their features may have, both in the

--- a/index.html
+++ b/index.html
@@ -68,12 +68,6 @@ change in one place may impact other feature designers or end users in
 another. New features, and additions or changes to existing features, should
 bring benefits to end users of the web, and avoid doing harms.
 
-The questions in this document are to help specification authors as they think
-through the impacts implementations of their features may have, both in the
-immediate scope of their work, as well as more widely. The questions encourage
-the reader to think about perspectives other than their own, as well as to
-think about worst case scenarios.
-
 Many things are not used in the way their creators intended them, which can be
 very positive or very harmful. Whilst specification authors can't be held
 responsible for every possible future implementation, in contexts which may
@@ -86,6 +80,18 @@ amplifying effect on social phenomena. Technology which provides a threat or a
 benefit to a small number may result in a wider society where the same threat
 or benefit is commonplace, when the technology is available as part of the web
 platform.
+
+### The purpose of this document {#purpose}
+
+This document is not a checklist for specifications. This document is not included as 
+part of the horizontal review process and is notintended for spec authors to 
+use as acceptance criteria.
+
+The questions in this document are to help specification authors as they think
+through the impacts implementations of their features may have, both in the
+immediate scope of their work, as well as more widely. The questions encourage
+the reader to think about perspectives other than their own, as well as to
+think about worst case scenarios.
 
 These questions are an accompaniment to the [[[ethical-web-principles]]],
 intended to help specification authors and reviewers to think more concretely


### PR DESCRIPTION
Clarify purpose of document to include what the document is not. Related to #18


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/societal-impact-questionnaire/pull/33.html" title="Last updated on Feb 5, 2026, 10:03 AM UTC (a95f42b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/societal-impact-questionnaire/33/20a88fd...a95f42b.html" title="Last updated on Feb 5, 2026, 10:03 AM UTC (a95f42b)">Diff</a>